### PR TITLE
updates metadata generation for provider and gpu pages

### DIFF
--- a/app/gpus/metadata.js
+++ b/app/gpus/metadata.js
@@ -1,0 +1,7 @@
+import { generateMetadata } from '@/app/metadata';
+
+export const metadata = generateMetadata({
+    title: 'GPU Hardware and Use Cases | Cloud GPU Guide',
+    description: 'Learn about different GPU types and their best use cases for machine learning, AI art generation, and data science. Compare cloud GPU specifications and capabilities.',
+    path: '/gpus'
+}); 

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -5,11 +5,13 @@ import MLResources from '@/components/learn/MLResources';
 import OngoingLearning from '@/components/learn/OngoingLearning';
 import LearningOverview from '@/components/learn/LearningOverview';
 import VideoCarousel, { VideoType } from '@/components/learn/VideoCarousel';
+import { generateMetadata } from '@/app/metadata';
 
-export const metadata = {
+export const metadata = generateMetadata({
   title: 'Machine Learning and AI - Learning Path',
   description: 'A comprehensive guide on Machine Learning and AI, designed for practical application with GPU computing. Start with foundational concepts, then build and deploy advanced models.',
-};
+  path: '/learn'
+});
 
 const ongoingLearningData = {
   stayUpdated: [

--- a/app/metadata.js
+++ b/app/metadata.js
@@ -24,8 +24,26 @@ export const defaultMetadata = {
   },
   verification: {
     google: 'your-google-verification-code',
+  },
+  // Add default alternates for canonical URLs
+  alternates: {
+    canonical: siteConfig.url
   }
 };
+
+// Helper function to generate metadata with canonical URL
+export function generateMetadata({ title, description, path = '' }) {
+  return {
+    ...defaultMetadata,
+    title,
+    description,
+    alternates: {
+      canonical: `${siteConfig.url}${path}`
+    },
+    openGraph: generateOpenGraph({ title, description, path }),
+    twitter: generateTwitter({ title, description })
+  };
+}
 
 // Helper function to generate OpenGraph metadata
 export function generateOpenGraph({ title, description, path = '', images = ['/og-image.png'] }) {

--- a/app/page.js
+++ b/app/page.js
@@ -7,23 +7,16 @@ import ProviderInfoCard from '@/components/ProviderInfoCard';
 import Superlatives from '@/components/Superlatives';
 import { getAllProviderSlugs } from '@/lib/utils/provider';
 import { FilterProvider } from '@/lib/context/FilterContext';
-import { generateOpenGraph, generateProviderStructuredData } from './metadata';
+import { generateMetadata } from './metadata';
 
 const HOME_TITLE = 'Cloud GPU Price Comparison | Find the Best AI GPU Deals';
 const HOME_DESCRIPTION = 'Compare cloud GPU prices across major providers like AWS, Google Cloud, and Azure. Find the most cost-effective GPUs for machine learning and AI workloads.';
 
-export const metadata = {
+export const metadata = generateMetadata({
   title: HOME_TITLE,
   description: HOME_DESCRIPTION,
-  alternates: {
-    canonical: 'https://computeprices.com'
-  },
-  openGraph: generateOpenGraph({
-    title: HOME_TITLE,
-    description: HOME_DESCRIPTION,
-    path: '/'
-  })
-};
+  path: '/'
+});
 
 export default async function Home() {
   const providerSlugs = await getAllProviderSlugs();

--- a/lib/utils/gpu.js
+++ b/lib/utils/gpu.js
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase';
+import { siteConfig } from '@/app/metadata';
 
 export async function getGPUBySlug(slug) {
   try {
@@ -30,15 +31,20 @@ export async function generateGPUMetadata(gpu) {
 
   const title = `${gpu.name} GPU Pricing & Specs Comparison | Compute Prices`;
   const description = `Compare ${gpu.name} GPU prices across cloud providers. Find the best deals and specifications for ${gpu.name} instances for machine learning and AI workloads.`;
+  const path = `/gpus/${gpu.slug}`;
 
   return {
     title,
     description,
     keywords: [gpu.name, 'GPU pricing', 'cloud GPU', 'ML GPU', 'AI GPU', 'machine learning', gpu.name + ' cloud', gpu.name + ' pricing'],
+    alternates: {
+      canonical: `${siteConfig.url}${path}`
+    },
     openGraph: {
       title,
       description,
-      url: `https://computeprices.com/gpus/${gpu.slug}`,
+      url: `${siteConfig.url}${path}`,
+      siteName: siteConfig.name,
       images: [
         {
           url: gpu.image_url || '/og-image.png',
@@ -47,6 +53,8 @@ export async function generateGPUMetadata(gpu) {
           alt: `${gpu.name} GPU Comparison`,
         },
       ],
+      locale: 'en_US',
+      type: 'website',
     },
     twitter: {
       card: 'summary_large_image',

--- a/lib/utils/provider.js
+++ b/lib/utils/provider.js
@@ -1,4 +1,5 @@
 import providersData from '@/data/providers.json';
+import { siteConfig } from '@/app/metadata';
 
 export async function getProviderBySlug(slug) {
   return providersData.find(p => p.slug === slug) || null;
@@ -13,6 +14,7 @@ export async function generateProviderMetadata(provider) {
 
   const title = `${provider.name} GPU Cloud Pricing & Comparison | Compute Prices`;
   const description = `Compare ${provider.name} GPU instances and pricing. Find the best ${provider.name} cloud GPU options for machine learning, AI, and compute workloads.`;
+  const path = `/providers/${provider.slug}`;
 
   const keywords = [
     provider.name,
@@ -31,11 +33,14 @@ export async function generateProviderMetadata(provider) {
     title,
     description,
     keywords,
+    alternates: {
+      canonical: `${siteConfig.url}${path}`
+    },
     openGraph: {
       title,
       description,
-      url: `https://computeprices.com/providers/${provider.slug}`,
-      siteName: 'Compute Prices',
+      url: `${siteConfig.url}${path}`,
+      siteName: siteConfig.name,
       images: [
         {
           url: provider.logo_url || '/og-image.png',
@@ -54,7 +59,7 @@ export async function generateProviderMetadata(provider) {
       images: [provider.logo_url || '/og-image.png'],
     },
     other: {
-      'og:site_name': 'Compute Prices',
+      'og:site_name': siteConfig.name,
       'og:type': 'website',
     },
   };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,21 @@ const nextConfig = {
             },
         ],
     },
+    async redirects() {
+        return [
+            {
+                source: '/:path*',
+                has: [
+                    {
+                        type: 'host',
+                        value: 'www.computeprices.com',
+                    },
+                ],
+                destination: 'https://computeprices.com/:path*',
+                permanent: true,
+            },
+        ];
+    },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request introduces a new metadata generation system across several files, aiming to standardize and improve the handling of metadata for various pages. The most important changes include the addition of a `generateMetadata` function, updates to existing metadata definitions to utilize this new function, and the introduction of canonical URLs.

### Metadata Generation System:

* [`app/metadata.js`](diffhunk://#diff-a4926bdc40971b28eaffe8a2422bc19f26df63ee40001cc28900a593e4b8a3a8R27-R47): Added a `generateMetadata` function to standardize metadata creation, including canonical URLs and OpenGraph metadata.
* [`app/gpus/metadata.js`](diffhunk://#diff-172da3d8f3688cd1a2b06aa4923f4f4125810f2c41f30b3d9862f6e9930aaf28R1-R7): Implemented the new `generateMetadata` function for GPU-related metadata.
* [`app/learn/page.tsx`](diffhunk://#diff-4541facc16d4b71650789f8bcaed4cb7041edc2114459bd796e71acb43f07e4fR8-R14): Updated the metadata definition to use the `generateMetadata` function.
* [`app/page.js`](diffhunk://#diff-85f77f2c1442a140dbd75e6b00ed6eb2016609ebea923ed3bbcb82d117d772f3L10-R19): Refactored the home page metadata to use the `generateMetadata` function.

### Canonical URLs and OpenGraph Improvements:

* [`lib/utils/gpu.js`](diffhunk://#diff-d1147778f979490ce3654e466c422e4cd71d692ab2e025a3d703aa394b6439e3R34-R47): Enhanced the `generateGPUMetadata` function to include canonical URLs and additional OpenGraph properties. [[1]](diffhunk://#diff-d1147778f979490ce3654e466c422e4cd71d692ab2e025a3d703aa394b6439e3R34-R47) [[2]](diffhunk://#diff-d1147778f979490ce3654e466c422e4cd71d692ab2e025a3d703aa394b6439e3R56-R57)
* [`lib/utils/provider.js`](diffhunk://#diff-d05abc81f297a5c58803afdb13ca6b5bda913600d913c492f18d5317881625abR17): Updated the `generateProviderMetadata` function to incorporate canonical URLs and improved OpenGraph metadata. [[1]](diffhunk://#diff-d05abc81f297a5c58803afdb13ca6b5bda913600d913c492f18d5317881625abR17) [[2]](diffhunk://#diff-d05abc81f297a5c58803afdb13ca6b5bda913600d913c492f18d5317881625abR36-R43) [[3]](diffhunk://#diff-d05abc81f297a5c58803afdb13ca6b5bda913600d913c492f18d5317881625abL57-R62)

### Additional Changes:

* [`next.config.mjs`](diffhunk://#diff-18c049b08c4a0f5ab451c598aeb2c4848bb9d7877b51ca3e5effb94a225814d2R10-R24): Added a redirect rule to ensure all traffic from `www.computeprices.com` is redirected to `computeprices.com`.
* Various files: Imported `siteConfig` from `app/metadata` to access site-wide configuration settings. [[1]](diffhunk://#diff-d1147778f979490ce3654e466c422e4cd71d692ab2e025a3d703aa394b6439e3R2) [[2]](diffhunk://#diff-d05abc81f297a5c58803afdb13ca6b5bda913600d913c492f18d5317881625abR2)